### PR TITLE
Removing jack-plumbing, jacktrip-receive and jacktrip-send services.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -32,8 +32,11 @@ const (
 	// MaxClientsPerProcessor is the number of JackTrip clients to support per logical processor
 	MaxClientsPerProcessor = 6 // add 1 (20%) for Jamulus bridge, etc
 
-	// SuperColliderServiceName is the name of the systemd service for the SuperCollider server
-	SuperColliderServiceName = "scsynth.service"
+	// SCSynthServiceName is the name of the systemd service for the SuperCollider scsynth server
+	SCSynthServiceName = "scsynth.service"
+
+	// SupernovaServiceName is the name of the systemd service for the SuperCollider supernova server
+	SupernovaServiceName = "supernova.service"
 
 	// SCLangServiceName is the name of the systemd service for the SuperCollider language runtime
 	SCLangServiceName = "sclang.service"

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,22 +33,13 @@ const (
 	MaxClientsPerProcessor = 6 // add 1 (20%) for Jamulus bridge, etc
 
 	// SuperColliderServiceName is the name of the systemd service for the SuperCollider server
-	SuperColliderServiceName = "supernova.service"
+	SuperColliderServiceName = "scsynth.service"
 
 	// SCLangServiceName is the name of the systemd service for the SuperCollider language runtime
 	SCLangServiceName = "sclang.service"
 
 	// JackAutoconnectServiceName is the name of the systemd service for connecting jack clients
 	JackAutoconnectServiceName = "jack-autoconnect.service"
-
-	// JackPlumbingServiceName is the name of the systemd service for connecting jack clients
-	JackPlumbingServiceName = "jack-plumbing.service"
-
-	// JackTripReceiveServiceName is the name of the systemd service for connecting jack client inputs
-	JackTripReceiveServiceName = "jacktrip-receive.service"
-
-	// JackTripSendServiceName is the name of the systemd service for connecting jack client outputs
-	JackTripSendServiceName = "jacktrip-send.service"
 
 	// JamulusServerServiceName is the name of the systemd service for the Jamulus server
 	JamulusServerServiceName = "jamulus-server.service"

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,7 +69,7 @@ const (
 	SCLangConfigTemplate = "SCLANG_OPTS=%s %s\n"
 
 	// SuperColliderConfigTemplate is the template used to generate /tmp/default/supercollider file on audio servers
-	SuperColliderConfigTemplate = "SC_OPTS=-i %d -o %d -m %d -z %d -a 2570\n"
+	SuperColliderConfigTemplate = "SC_OPTS=-i %d -o %d -a %d -m %d -z %d -n 4096 -d 2048 %s\n"
 
 	// EC2InstanceIDURL is url using EC2 metadata service that returns the instance-id
 	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
@@ -214,21 +214,47 @@ func updateSuperColliderConfigs(config client.AgentConfig) {
 	maxClients := runtime.NumCPU() * MaxClientsPerProcessor
 	numInputChannels := maxClients * 2
 	numOutputChannels := maxClients * 2
-	scMemorySize := 8192
+	audioBusses := (numInputChannels + numOutputChannels) * 2
+
+	// bump memory for larger systems
+	scMemorySize := 65536
 	if maxClients > 50 {
-		scMemorySize = 16384
+		scMemorySize = 262144
 	}
+
+	// lower bufsize if jack is lower
 	scBufSize := 64
 	if config.Period < 64 {
 		scBufSize = config.Period
 	}
-	scConfig := fmt.Sprintf(SuperColliderConfigTemplate, numInputChannels, numOutputChannels, scMemorySize, scBufSize)
+
+	// append threads when using supernova because the default is way too high/inefficient
+	extraOpts := ""
+	if runtime.NumCPU() <= 50 {
+
+		// use number of physical cores for dsp threads
+		scThreads := runtime.NumCPU() / 2
+		if scThreads > 4 {
+			// there seems to be no advantage of ever using > 4 threads
+			// in fact, it consistently degrades performance
+			scThreads = 4
+		}
+
+		extraOpts = fmt.Sprintf("-T %d", scThreads)
+	}
+
+	// create service config using template
+	scConfig := fmt.Sprintf(SuperColliderConfigTemplate,
+		numInputChannels, numOutputChannels, audioBusses,
+		scMemorySize, scBufSize, extraOpts)
+
+	// write SuperCollider (supercollider) service config file
 	err := ioutil.WriteFile(PathToSuperColliderConfig, []byte(scConfig), 0644)
 	if err != nil {
 		log.Error(err, "Failed to save SuperCollider config", "path", PathToSuperColliderConfig)
 	}
 
-	// write SuperCollider (sclang) config file
+	// write SuperCollider (sclang) service config file
 	sclangConfig := fmt.Sprintf(SCLangConfigTemplate, config.MixBranch, PathToSuperColliderStartupFile)
 	err = ioutil.WriteFile(PathToSCLangConfig, []byte(sclangConfig), 0644)
 	if err != nil {

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/coreos/go-systemd/v22/dbus"
@@ -193,7 +194,7 @@ func restartAllServices(config client.AgentConfig, isServer bool) {
 
 	// stop any managed services that are active
 	units, err := conn.ListUnitsByNames([]string{JackServiceName,
-		SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName,
+		SCSynthServiceName, SupernovaServiceName, SCLangServiceName, JackAutoconnectServiceName,
 		JackTripServiceName, JamulusServiceName, JamulusServerServiceName, JamulusBridgeServiceName})
 	if err != nil {
 		log.Error(err, "Failed to get status of managed services")
@@ -218,7 +219,11 @@ func restartAllServices(config client.AgentConfig, isServer bool) {
 	case client.JackTrip:
 		servicesToStart = []string{JackServiceName, JackTripServiceName}
 		if isServer {
-			servicesToStart = append(servicesToStart, SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName)
+			if runtime.NumCPU() > 50 {
+				servicesToStart = append(servicesToStart, SCSynthServiceName, SCLangServiceName, JackAutoconnectServiceName)
+			} else {
+				servicesToStart = append(servicesToStart, SupernovaServiceName, SCLangServiceName, JackAutoconnectServiceName)
+			}
 		}
 	case client.Jamulus:
 		if isServer {
@@ -230,7 +235,11 @@ func restartAllServices(config client.AgentConfig, isServer bool) {
 		if isServer {
 			servicesToStart = []string{JackServiceName, JackTripServiceName}
 			servicesToStart = append(servicesToStart, JamulusServerServiceName, JamulusBridgeServiceName)
-			servicesToStart = append(servicesToStart, SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName)
+			if runtime.NumCPU() > 50 {
+				servicesToStart = append(servicesToStart, SCSynthServiceName, SCLangServiceName, JackAutoconnectServiceName)
+			} else {
+				servicesToStart = append(servicesToStart, SupernovaServiceName, SCLangServiceName, JackAutoconnectServiceName)
+			}
 		} else {
 			switch config.Quality {
 			case 0:

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/coreos/go-systemd/v22/dbus"
@@ -193,8 +192,8 @@ func restartAllServices(config client.AgentConfig, isServer bool) {
 	defer conn.Close()
 
 	// stop any managed services that are active
-	units, err := conn.ListUnitsByNames([]string{JackServiceName, SuperColliderServiceName, SCLangServiceName,
-		JackAutoconnectServiceName, JackPlumbingServiceName, JackTripReceiveServiceName, JackTripSendServiceName,
+	units, err := conn.ListUnitsByNames([]string{JackServiceName,
+		SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName,
 		JackTripServiceName, JamulusServiceName, JamulusServerServiceName, JamulusBridgeServiceName})
 	if err != nil {
 		log.Error(err, "Failed to get status of managed services")
@@ -219,11 +218,7 @@ func restartAllServices(config client.AgentConfig, isServer bool) {
 	case client.JackTrip:
 		servicesToStart = []string{JackServiceName, JackTripServiceName}
 		if isServer {
-			if runtime.NumCPU() > 36 {
-				servicesToStart = append(servicesToStart, JackTripReceiveServiceName, JackTripSendServiceName, JackPlumbingServiceName)
-			} else {
-				servicesToStart = append(servicesToStart, SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName)
-			}
+			servicesToStart = append(servicesToStart, SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName)
 		}
 	case client.Jamulus:
 		if isServer {
@@ -235,11 +230,7 @@ func restartAllServices(config client.AgentConfig, isServer bool) {
 		if isServer {
 			servicesToStart = []string{JackServiceName, JackTripServiceName}
 			servicesToStart = append(servicesToStart, JamulusServerServiceName, JamulusBridgeServiceName)
-			if runtime.NumCPU() > 36 {
-				servicesToStart = append(servicesToStart, JackTripReceiveServiceName, JackTripSendServiceName, JackPlumbingServiceName)
-			} else {
-				servicesToStart = append(servicesToStart, SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName)
-			}
+			servicesToStart = append(servicesToStart, SuperColliderServiceName, SCLangServiceName, JackAutoconnectServiceName)
 		} else {
 			switch config.Quality {
 			case 0:


### PR DESCRIPTION
All jacktrip audio will now always passed through SuperCollider, regardless of server size.

Using scsynth instead of supernova, for the time being. Still testing and comparing..