### PR TITLE
Reset ping time on all sendPing() calls

### DIFF
--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -36,9 +36,7 @@ const (
 func sendPing(ping client.AgentPing, apiOrigin string) (client.AgentConfig, error) {
 	var config client.AgentConfig
 
-	if ping.StatsUpdatedAt.IsZero() {
-		ping.StatsUpdatedAt = time.Now()
-	}
+	ping.StatsUpdatedAt = time.Now()
 	
 	// update and encode ping content
 	pingBytes, err := json.Marshal(ping)


### PR DESCRIPTION
There's an issue here which can be reproduced with the following:
* Join a studio
* Wait for a few ping checks
* Disconnect from studio

Subsequent pings updated time no longer get updated because the AgentPing pointer is never updated after it runs through the new pingers.