### PR TITLE
Various changes to use "heartbeat" instead of "ping", where appropriate

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -102,34 +102,44 @@ func runOnDevice(apiOrigin string) {
 	go runHTTPServer(&wg, router, ":80")
 
 	// update avahi service config and restart daemon
-	ping := client.AgentPing{
-		AgentCredentials: credentials,
-		MAC:              mac,
-		Version:          getPatchVersion(),
-		Type:             soundDeviceType,
+	beat := client.DeviceHeartbeat{
+		MAC:     mac,
+		Version: getPatchVersion(),
+		Type:    soundDeviceType,
+		PingStats: client.PingStats{
+			StatsUpdatedAt: time.Now(),
+		},
 	}
-	updateAvahiServiceConfig(&ping, lastDeviceStatus)
+	updateAvahiServiceConfig(beat, credentials, lastDeviceStatus)
 
-	// start ping server to send pings and update agent config
+	// start sending heartbeats and updating agent configs
+	wsm := WebSocketManager{
+		ConfigChannel:    make(chan client.AgentConfig, 100),
+		HeartbeatChannel: make(chan client.DeviceHeartbeat, 100),
+		APIOrigin:        apiOrigin,
+		Credentials:      credentials,
+	}
 	wg.Add(1)
-	wsm := WebSocketManager{ConfigChannel: make(chan client.AgentConfig, 100), PingStatsChannel: make(chan client.PingStats, 100)}
-	go runDeviceConfigPinger(&wg, &ping, &wsm, apiOrigin)
-	wg.Add(1)
-	go wsm.sendPingStatsHandler(&wg, &ping, apiOrigin)
+	go wsm.sendHeartbeatHandler(&wg)
 	wg.Add(1)
 	go wsm.recvConfigHandler(&wg)
 
+	// start sending heartbeats and updating agent configs
+	wg.Add(1)
+	go sendDeviceHeartbeats(&wg, &beat, &wsm, apiOrigin)
+
 	// Start a config handler to update config changes
 	wg.Add(1)
-	go configUpdateHandler(&wg, &ping, &wsm)
+	go deviceConfigUpdateHandler(&wg, &beat, &wsm)
 
 	// wait for everything to complete
 	wg.Wait()
 }
 
-func configUpdateHandler(wg *sync.WaitGroup, ping *client.AgentPing, wsm *WebSocketManager) {
+// deviceConfigUpdateHandler receives and processes device config updates
+func deviceConfigUpdateHandler(wg *sync.WaitGroup, beat *client.DeviceHeartbeat, wsm *WebSocketManager) {
 	defer wg.Done()
-	log.Info("Starting getDeviceConfigHandler")
+	log.Info("Starting deviceConfigUpdateHandler")
 	for {
 		newDeviceConfig, ok := <-wsm.ConfigChannel
 		if !ok {
@@ -141,45 +151,54 @@ func configUpdateHandler(wg *sync.WaitGroup, ping *client.AgentPing, wsm *WebSoc
 			if wsm.IsInitialized && (newDeviceConfig.Enabled == false || newDeviceConfig.Host == "") {
 				wsm.CloseConnection()
 			}
-			handleDeviceUpdate(ping, newDeviceConfig)
+			handleDeviceUpdate(beat, wsm.Credentials, newDeviceConfig)
 		}
 	}
 }
 
-// runDeviceConfigPinger sends pings to service and manages config updates
-func runDeviceConfigPinger(wg *sync.WaitGroup, ping *client.AgentPing, wsm *WebSocketManager, apiOrigin string) {
+// sendDeviceHeartbeats sends device heartbeat messages to the backend api, and receives config updates
+func sendDeviceHeartbeats(wg *sync.WaitGroup, beat *client.DeviceHeartbeat, wsm *WebSocketManager, apiOrigin string) {
 	defer wg.Done()
-	log.Info("Starting agent ping server")
+	log.Info("Sending device heartbeats")
 
 	for {
-		// If the device isn't connected to an audio server, there is no socket connection to the api server so use a regular ping endpoint.
-		if !wsm.IsInitialized || currentDeviceConfig.Host == "" {
-			newDeviceConfig, err := sendPing(*ping, apiOrigin)
-
-			if err != nil {
-				updateDeviceStatus(ping, "error")
-				panic(err)
-			}
-			if newDeviceConfig != currentDeviceConfig {
-				wsm.ConfigChannel <- newDeviceConfig
-			}
-		}
-		ResetPing(ping)
 		if currentDeviceConfig.Enabled == true && currentDeviceConfig.Host != "" {
-			// Initialize a socket connection
-			wsm.InitConnection(wg, ping, apiOrigin) // no need for error check since failure defaults to http ping/config exhcange
+			// device is connected to an audio server
+
+			// Initialize a socket connection (do nothing if already connected)
+			wsm.InitConnection(wg, beat.MAC) // no need for error check since failure defaults to http heartbeat/config exchange
 
 			// Measure connection latency to the audio server
-			MeasurePingStats(ping, apiOrigin, currentDeviceConfig.Host, HTTPServerPort) // blocks for 5 seconds instead of time sleep
-			wsm.PingStatsChannel <- ping.PingStats
+			MeasurePingStats(beat, apiOrigin, currentDeviceConfig.Host, HTTPServerPort) // blocks for 5 seconds instead of time sleep
+
+			// send heartbeat to channel, for delivery over websocket
+			wsm.HeartbeatChannel <- *beat
+
 		} else {
-			time.Sleep(AgentPingInterval * time.Second)
+			// device isn't connected to an audio server
+			// there is no websocket connection to the api server so use a HTTP endpoint
+
+			// reset ping stats to be empty, with current timestamp
+			beat.PingStats = client.PingStats{StatsUpdatedAt: time.Now()}
+
+			// send http heartbeat message to api server
+			newDeviceConfig, err := sendHTTPHeartbeat(*beat, apiOrigin)
+			if err != nil {
+				updateDeviceStatus(*beat, wsm.Credentials, "error")
+				panic(err)
+			}
+
+			// send config to channel
+			wsm.ConfigChannel <- newDeviceConfig
+
+			// sleep for heartbeat interval
+			time.Sleep(HeartbeatInterval * time.Second)
 		}
 	}
 }
 
 // handleDeviceUpdate handles updates to device configuratiosn
-func handleDeviceUpdate(ping *client.AgentPing, config client.AgentConfig) {
+func handleDeviceUpdate(beat *client.DeviceHeartbeat, credentials client.AgentCredentials, config client.AgentConfig) {
 	// update ALSA card settings
 	if config.ALSAConfig != currentDeviceConfig.ALSAConfig {
 		updateALSASettings(config)
@@ -191,7 +210,7 @@ func handleDeviceUpdate(ping *client.AgentPing, config client.AgentConfig) {
 		// more changes required -> reset everything
 
 		// update managed config files
-		updateServiceConfigs(config, strings.Replace(ping.MAC, ":", "", -1), false)
+		updateServiceConfigs(config, strings.Replace(beat.MAC, ":", "", -1), false)
 
 		// shutdown or restart managed services
 		restartAllServices(config, false)
@@ -201,9 +220,9 @@ func handleDeviceUpdate(ping *client.AgentPing, config client.AgentConfig) {
 
 	// update device status in avahi service config, if necessary
 	if config.Enabled {
-		updateDeviceStatus(ping, "connected")
+		updateDeviceStatus(*beat, credentials, "connected")
 	} else {
-		updateDeviceStatus(ping, "not connected")
+		updateDeviceStatus(*beat, credentials, "not connected")
 	}
 }
 
@@ -426,7 +445,7 @@ func updateALSASettingsUSBPnPSoundDevice(config client.AgentConfig) {
 }
 
 // updateAvahiServiceConfig generates a new /etc/avahi/services/jacktrip-agent.service file
-func updateAvahiServiceConfig(ping *client.AgentPing, status string) {
+func updateAvahiServiceConfig(beat client.DeviceHeartbeat, credentials client.AgentCredentials, status string) {
 	// ensure config directory exists
 	err := os.MkdirAll("/tmp/avahi/services", 0755)
 	if err != nil {
@@ -434,7 +453,7 @@ func updateAvahiServiceConfig(ping *client.AgentPing, status string) {
 		return
 	}
 
-	apiHash := client.GetAPIHash(ping.APISecret)
+	apiHash := client.GetAPIHash(credentials.APISecret)
 	avahiServiceConfig := fmt.Sprintf(`<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
@@ -448,7 +467,7 @@ func updateAvahiServiceConfig(ping *client.AgentPing, status string) {
 		<txt-record value-format="text">apiHash=%s</txt-record>
 	</service>
 </service-group>
-`, status, ping.Version, ping.MAC, apiHash)
+`, status, beat.Version, beat.MAC, apiHash)
 
 	err = ioutil.WriteFile(PathToAvahiServiceFile, []byte(avahiServiceConfig), 0644)
 	if err != nil {
@@ -459,10 +478,10 @@ func updateAvahiServiceConfig(ping *client.AgentPing, status string) {
 }
 
 // updateDeviceStatus updates the device status, including avahi config, if it has changed
-func updateDeviceStatus(ping *client.AgentPing, status string) {
+func updateDeviceStatus(beat client.DeviceHeartbeat, credentials client.AgentCredentials, status string) {
 	log.Info(fmt.Sprintf("Updated device status to %s", status))
 	if lastDeviceStatus != status {
-		updateAvahiServiceConfig(ping, status)
+		updateAvahiServiceConfig(beat, credentials, status)
 		lastDeviceStatus = status
 	}
 }

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -182,7 +182,7 @@ func sendDeviceHeartbeats(wg *sync.WaitGroup, beat *client.DeviceHeartbeat, wsm 
 			beat.PingStats = client.PingStats{StatsUpdatedAt: time.Now()}
 
 			// send http heartbeat message to api server
-			newDeviceConfig, err := sendHTTPHeartbeat(*beat, apiOrigin)
+			newDeviceConfig, err := sendHTTPHeartbeat(*beat, wsm.Credentials, apiOrigin)
 			if err != nil {
 				updateDeviceStatus(*beat, wsm.Credentials, "error")
 				panic(err)

--- a/cmd/deviceWSManager.go
+++ b/cmd/deviceWSManager.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -38,9 +39,9 @@ type WebSocketManager struct {
 }
 
 // InitConnection initializes a new connection if there is no connection or returns an existing connection
-func (wsm *WebSocketManager) InitConnection(wg *sync.WaitGroup, mac string) {
+func (wsm *WebSocketManager) InitConnection(wg *sync.WaitGroup, mac string) error {
 	if wsm.IsInitialized {
-		return
+		return nil
 	}
 
 	// Parse url and format a ws(s) url
@@ -63,13 +64,13 @@ func (wsm *WebSocketManager) InitConnection(wg *sync.WaitGroup, mac string) {
 
 	if err != nil {
 		wsm.IsInitialized = false
-		log.Error(err, "Websocket initialization error")
-	} else {
-		wsm.IsInitialized = true
-		log.Info("Websocket connected", "target", wsURL.String())
+		return errors.New("Websocket initialization error")
 	}
 
-	return
+	wsm.IsInitialized = true
+	log.Info("Websocket connected", "target", wsURL.String())
+
+	return nil
 }
 
 // CloseConnection closes an initialized connection in a websocketmanager

--- a/cmd/handlers_test.go
+++ b/cmd/handlers_test.go
@@ -15,10 +15,11 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io"
+	"io/ioutil"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestPayload struct {
@@ -48,7 +49,7 @@ func TestHandlePingRequestNoWS(t *testing.T) {
 	mockReq.Header.Set("Upgrade", "nada")
 	handlePingRequest(mockResp, mockReq)
 	resp := mockResp.Result()
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := ioutil.ReadAll(resp.Body)
 
 	tests := []TestResponseHeaders{
 		// Check Content-Type header
@@ -109,7 +110,7 @@ func TestRespondJSONValid(t *testing.T) {
 	payload := TestPayload{"mr-worldwide"}
 	RespondJSON(mockResp, 299, payload)
 	resp := mockResp.Result()
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := ioutil.ReadAll(resp.Body)
 
 	tests := []TestResponseHeaders{
 		// Check Content-Type header
@@ -139,7 +140,7 @@ func TestRespondJSONInvalid(t *testing.T) {
 	payload := make(chan int)
 	RespondJSON(mockResp, 298, payload)
 	resp := mockResp.Result()
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := ioutil.ReadAll(resp.Body)
 
 	tests := []TestResponseHeaders{
 		// Check Content-Type header

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -19,50 +19,47 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/jacktrip/jacktrip-agent/pkg/client"
 )
 
 const (
-	// AgentPingURL is the URL used to POST agent pings
+	// AgentPingURL is the URL used to POST HTTP heartbeats
 	AgentPingURL = "/agents/ping"
 
-	// AgentPingInterval is an interval between pings
-	AgentPingInterval = 5
+	// HeartbeatInterval is an interval between heartbeats
+	HeartbeatInterval = 5
 )
 
-// sendPing sends ping to service to retrieve config
-func sendPing(ping client.AgentPing, apiOrigin string) (client.AgentConfig, error) {
+// sendHTTPHeartbeat sends HTTP heartbeat to api and receives latest config
+func sendHTTPHeartbeat(beat interface{}, apiOrigin string) (client.AgentConfig, error) {
 	var config client.AgentConfig
 
-	ping.StatsUpdatedAt = time.Now()
-
-	// update and encode ping content
-	pingBytes, err := json.Marshal(ping)
+	// update and encode heartbeat content
+	beatBytes, err := json.Marshal(beat)
 	if err != nil {
-		log.Error(err, "Failed to marshal agent ping request")
+		log.Error(err, "Failed to marshal agent heartbeat request")
 		return config, err
 	}
 
-	// send ping request
-	r, err := http.Post(fmt.Sprintf("%s%s", apiOrigin, AgentPingURL), "application/json", bytes.NewReader(pingBytes))
+	// send heartbeat request
+	r, err := http.Post(fmt.Sprintf("%s%s", apiOrigin, AgentPingURL), "application/json", bytes.NewReader(beatBytes))
 	if err != nil {
-		log.Error(err, "Failed to send agent ping request")
+		log.Error(err, "Failed to send agent heartbeat request")
 		return config, err
 	}
 	defer r.Body.Close()
 
 	// check response status
 	if r.StatusCode != http.StatusOK {
-		log.Info("Bad response from agent ping", "status", r.StatusCode)
+		log.Info("Bad response from agent heartbeat", "status", r.StatusCode)
 		return config, err
 	}
 
 	// decode config from response
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&config); err != nil {
-		log.Error(err, "Failed to unmarshal agent ping response")
+		log.Error(err, "Failed to unmarshal agent heartbeat response")
 		return config, err
 	}
 

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -32,7 +32,7 @@ const (
 )
 
 // sendHTTPHeartbeat sends HTTP heartbeat to api and receives latest config
-func sendHTTPHeartbeat(beat interface{}, apiOrigin string) (client.AgentConfig, error) {
+func sendHTTPHeartbeat(beat interface{}, credentials client.AgentCredentials, apiOrigin string) (client.AgentConfig, error) {
 	var config client.AgentConfig
 
 	// update and encode heartbeat content
@@ -43,7 +43,11 @@ func sendHTTPHeartbeat(beat interface{}, apiOrigin string) (client.AgentConfig, 
 	}
 
 	// send heartbeat request
-	r, err := http.Post(fmt.Sprintf("%s%s", apiOrigin, AgentPingURL), "application/json", bytes.NewReader(beatBytes))
+	client := &http.Client{}
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s%s", apiOrigin, AgentPingURL), bytes.NewReader(beatBytes))
+	req.Header.Set("APIPrefix", credentials.APIPrefix)
+	req.Header.Set("APISecret", credentials.APISecret)
+	r, err := client.Do(req)
 	if err != nil {
 		log.Error(err, "Failed to send agent heartbeat request")
 		return config, err

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -105,23 +105,26 @@ func runOnServer(apiOrigin string) {
 	wg.Add(1)
 	go runHTTPServer(&wg, router, fmt.Sprintf("0.0.0.0:%s", HTTPServerPort))
 
+	// TODO: get server credentials
+	credentials := client.AgentCredentials{}
+
 	// start ping server to send pings and update agent config
 	beat := client.ServerHeartbeat{CloudID: getCloudID()}
 	wg.Add(1)
-	go sendServerHeartbeats(&wg, beat, apiOrigin)
+	go sendServerHeartbeats(&wg, beat, credentials, apiOrigin)
 
 	// wait for everything to complete
 	wg.Wait()
 }
 
 // sendServerHeartbeats sends heartbeat messages to api server and manages config updates
-func sendServerHeartbeats(wg *sync.WaitGroup, beat client.ServerHeartbeat, apiOrigin string) {
+func sendServerHeartbeats(wg *sync.WaitGroup, beat client.ServerHeartbeat, credentials client.AgentCredentials, apiOrigin string) {
 	defer wg.Done()
 
 	log.Info("Sending server heartbeats")
 
 	for {
-		config, err := sendHTTPHeartbeat(beat, apiOrigin)
+		config, err := sendHTTPHeartbeat(beat, credentials, apiOrigin)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/client/devices.go
+++ b/pkg/client/devices.go
@@ -92,7 +92,7 @@ type PingStats struct {
 	StdDevRtt time.Duration `json:"stddev_rtt" db:"stddev_rtt"`
 
 	// LatestRtt is the latest rtt sent via socket ping.
-	LatestRtt time.Duration `json:"latest_rtt db:"latest_rtt"`
+	LatestRtt time.Duration `json:"latest_rtt" db:"latest_rtt"`
 
 	// timestamp when the device stats were last updated
 	StatsUpdatedAt time.Time `json:"stats_updated_at" db:"stats_updated_at"`
@@ -112,13 +112,9 @@ func GetAPIHash(apiSecret string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(apiSecret)))
 }
 
-// AgentPing is used to receive ping from a device
-type AgentPing struct {
-	AgentCredentials
+// DeviceHeartbeat is used to send heartbeat messages from devices
+type DeviceHeartbeat struct {
 	PingStats
-
-	// Cloud identifier for server (used when running on cloud audio server)
-	CloudID string `json:"cloudId"`
 
 	// MAC address for ethernet device (used when running on raspberry pi device)
 	MAC string `json:"mac"`

--- a/pkg/client/devices_test.go
+++ b/pkg/client/devices_test.go
@@ -16,9 +16,10 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeviceConfig(t *testing.T) {
@@ -120,18 +121,15 @@ func TestGetAPIHash(t *testing.T) {
 	assert.Equal("b13dabc4285540382af3f280bfc55c0752806a177f896afa8ec568b0206c3bf5", result)
 }
 
-func TestAgentPing(t *testing.T) {
+func TestDeviceHeartbeat(t *testing.T) {
 	assert := assert.New(t)
 	var raw string
-	var target AgentPing
+	var target DeviceHeartbeat
 
-	// Parse JSON into AgentPing struct
-	raw = `{"apiPrefix": "black", "apiSecret": "pink", "cloudId": "aws", "mac": "00:1B:44:11:3A:B7", "version": "1.0.0", "type": "snd_rpi_hifiberry_dacplusadcpro", "pkts_recv": 832, "pkts_sent": 3, "min_rtt": 3, "max_rtt": -5, "avg_rtt": 301, "stddev_rtt": -10291, "stats_updated_at": "2021-08-11T10:28:32.487013776Z"}`
-	target = AgentPing{}
+	// Parse JSON into DeviceHeartbeat struct
+	raw = `{"mac": "00:1B:44:11:3A:B7", "version": "1.0.0", "type": "snd_rpi_hifiberry_dacplusadcpro", "pkts_recv": 832, "pkts_sent": 3, "min_rtt": 3, "max_rtt": -5, "avg_rtt": 301, "stddev_rtt": -10291, "stats_updated_at": "2021-08-11T10:28:32.487013776Z"}`
+	target = DeviceHeartbeat{}
 	json.Unmarshal([]byte(raw), &target)
-	assert.Equal("black", target.APIPrefix)
-	assert.Equal("pink", target.APISecret)
-	assert.Equal("aws", target.CloudID)
 	assert.Equal("00:1B:44:11:3A:B7", target.MAC)
 	assert.Equal("1.0.0", target.Version)
 	assert.Equal("snd_rpi_hifiberry_dacplusadcpro", target.Type)

--- a/pkg/client/servers.go
+++ b/pkg/client/servers.go
@@ -61,3 +61,9 @@ type ServerConfig struct {
 	// true if enabled
 	Enabled types.BitBool `json:"enabled" db:"enabled"`
 }
+
+// ServerHeartbeat is used to send heartbeat messages from servers / studios
+type ServerHeartbeat struct {
+	// Cloud identifier for server (used when running on cloud audio server)
+	CloudID string `json:"cloudId"`
+}

--- a/pkg/client/servers_test.go
+++ b/pkg/client/servers_test.go
@@ -16,8 +16,9 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConstants(t *testing.T) {
@@ -45,4 +46,16 @@ func TestServerConfig(t *testing.T) {
 	assert.Equal(true, bool(target.Stereo))
 	assert.Equal(false, bool(target.LoopBack))
 	assert.Equal(true, bool(target.Enabled))
+}
+
+func TestServerHeartbeat(t *testing.T) {
+	assert := assert.New(t)
+	var raw string
+	var target ServerHeartbeat
+
+	// Parse JSON into DeviceHeartbeat struct
+	raw = `{"cloudId": "aws"}`
+	target = ServerHeartbeat{}
+	json.Unmarshal([]byte(raw), &target)
+	assert.Equal("aws", target.CloudID)
 }


### PR DESCRIPTION
Replaced AgentPing with DeviceHeartbeat and ServerHeartbeat

Updated logic in sendDeviceHeartbeats to more clearly express and
document the two possible paths

Updated recvConfigHandler in WebSockerManager to sleep if not
initialized/connected, or block on read (up to 5 minutes) if
receiving via websocket