### PR TITLE
Return error if StatusCode is not OK for sendHTTPHeartbeat.

### DIFF
--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -56,8 +56,7 @@ func sendHTTPHeartbeat(beat interface{}, credentials client.AgentCredentials, ap
 
 	// check response status
 	if r.StatusCode != http.StatusOK {
-		log.Info("Bad response from agent heartbeat", "status", r.StatusCode)
-		return config, err
+		return config, fmt.Errorf("Bad response from agent heartbeat: Status=%d", r.StatusCode)
 	}
 
 	// decode config from response


### PR DESCRIPTION
Previously, err was nil so it would try to process an invalid config response.