### PR TITLE
Revising metric format for compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@
 
 all: lint fmt agent-amd64 agent-arm
 
+local:
+	@go build -o jacktrip-agent ./cmd
+
 agent-amd64:
 	@docker buildx build --platform linux/amd64 --target=artifact --output type=local,dest=./ .
 

--- a/cmd/autoconnector.go
+++ b/cmd/autoconnector.go
@@ -340,7 +340,7 @@ func (ac *AutoConnector) Run(wg *sync.WaitGroup) {
 // CollectMetrics collects JACK + JackTrip metrics
 // TODO: Jamulus
 func (ac *AutoConnector) CollectMetrics() []client.ServerMetric {
-	metrics := []client.ServerMetric{{Name: "virtual_studio_up", Service: "jackd", Value: 0}}
+	metrics := []client.ServerMetric{{Name: "virtual_studio_jackd_up", Value: 0}}
 	jackClient, err := initClient("", nil, nil, false)
 	if err != nil {
 		return metrics
@@ -350,11 +350,11 @@ func (ac *AutoConnector) CollectMetrics() []client.ServerMetric {
 	// Update "virtual_studio_up" now that jackd is running
 	metrics[0].Value = 1
 
-	allPorts := client.ServerMetric{Name: "virtual_studio_connections", Service: "total", Value: 0}
-	systemPorts := client.ServerMetric{Name: "virtual_studio_connections", Service: "system", Value: 0}
-	scPorts := client.ServerMetric{Name: "virtual_studio_connections", Service: "supercollider", Value: 0}
-	jamulusPorts := client.ServerMetric{Name: "virtual_studio_connections", Service: "jamulus", Value: 0}
-	clientPorts := client.ServerMetric{Name: "virtual_studio_connections", Service: "clients_total", Value: 0}
+	allPorts := client.ServerMetric{Name: "virtual_studio_connections_total", Value: 0}
+	systemPorts := client.ServerMetric{Name: "virtual_studio_connections_system", Value: 0}
+	scPorts := client.ServerMetric{Name: "virtual_studio_connections_supercollider", Value: 0}
+	jamulusPorts := client.ServerMetric{Name: "virtual_studio_connections_jamulus", Value: 0}
+	clientPorts := client.ServerMetric{Name: "virtual_studio_connections_clients_total", Value: 0}
 
 	ports := jackClient.GetPorts(".*", "", 0)
 	for _, port := range ports {
@@ -383,7 +383,7 @@ func (ac *AutoConnector) CollectMetrics() []client.ServerMetric {
 	metrics = append(metrics, clientPorts)
 
 	// Count the number of unique clients, removing Jamulus
-	uniqueClients := client.ServerMetric{Name: "virtual_studio_connections", Service: "clients_unique", Value: float64(len(ac.KnownClients) - 1)}
+	uniqueClients := client.ServerMetric{Name: "virtual_studio_clients_unique", Value: float64(len(ac.KnownClients) - 1)}
 	metrics = append(metrics, uniqueClients)
 	for key := range ac.KnownClients {
 		if key == "Jamulus" {

--- a/pkg/client/servers.go
+++ b/pkg/client/servers.go
@@ -15,6 +15,8 @@
 package client
 
 import (
+	"encoding/json"
+
 	"github.com/jmoiron/sqlx/types"
 )
 
@@ -78,9 +80,15 @@ type ServerMetric struct {
 	// Metric value
 	Value float64 `json:"value"`
 
-	// Service tag for filtering/grouping
-	Service string `json:"service,omitempty"`
-
 	// Client name tag for filtering/grouping
 	ClientName string `json:"clientName,omitempty"`
+}
+
+func (m *ServerMetric) MarshalJSON() ([]byte, error) {
+	result := make(map[string]interface{})
+	result[m.Name] = m.Value
+	if m.ClientName != "" {
+		result["clientName"] = m.ClientName
+	}
+	return json.Marshal(result)
 }


### PR DESCRIPTION
Changing the format of these metrics so the name as-passed-in becomes the final metric name. Otherwise, there's some auto-name-normalization that occurs such that we get `virtual_studio_connections_total_value` instead of just `virtual_studio_connections_total`.