### PR TITLE
Only enable recorder on cloud-managed servers

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -235,7 +235,9 @@ func handleServerUpdate(config client.AgentConfig) {
 		// jack client will error when the server is only using Jamulus
 		if config.Type != client.Jamulus {
 			ac.SetupClient()
-			recorder.SetupClient()
+			if os.Getenv("JACKTRIP_CLOUD_ID") != "" {
+				recorder.SetupClient()
+			}
 		}
 	}
 


### PR DESCRIPTION
Not sure if we want this or not, but I was thinking that self-hosted studios may not want to support this ability? Mainly because:
* it relies on specific versions of external utilities (ffmpeg)
* it consumes extra cpu/memory
* will constantly write to disk

Additionally, the stream-ability would be limited on self-hosted servers.