### PR TITLE
Adding expiresAt in heartbeat so server is aware of expiration time

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -150,6 +150,7 @@ func deviceConfigUpdateHandler(wg *sync.WaitGroup, beat *client.DeviceHeartbeat,
 
 		// just copy over parameters that we want to silently ignore
 		currentDeviceConfig.Broadcast = newDeviceConfig.Broadcast
+		currentDeviceConfig.ExpiresAt = newDeviceConfig.ExpiresAt
 
 		if newDeviceConfig != currentDeviceConfig {
 			// remove secrets before logging

--- a/pkg/client/devices.go
+++ b/pkg/client/devices.go
@@ -82,6 +82,9 @@ type AgentConfig struct {
 
 	// authorization token used by jacktrip-agent to access studio servers
 	AuthToken string `json:"authToken" db:"auth_token"`
+
+	// timestamp when the server will automatically be paused
+	ExpiresAt time.Time `json:"expiresAt" db:"expires_at"`
 }
 
 // PingStats defines a ping statistics to an audio server

--- a/pkg/client/devices_test.go
+++ b/pkg/client/devices_test.go
@@ -77,7 +77,7 @@ func TestAgentConfig(t *testing.T) {
 	var target AgentConfig
 
 	// Parse JSON into AgentConfig struct
-	raw = `{"period": 3, "queueBuffer": 128, "devicePort": 8000, "reverb": 42, "limiter": true, "compressor": 0, "quality": 2, "captureBoost": true, "playbackBoost": 0, "captureVolume": 100, "playbackVolume": 0, "type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "inputChannels": 2, "outputChannels": 2, "loopback": false, "enabled": true, "authToken": "foobar"}`
+	raw = `{"period": 3, "queueBuffer": 128, "devicePort": 8000, "reverb": 42, "limiter": true, "compressor": 0, "quality": 2, "captureBoost": true, "playbackBoost": 0, "captureVolume": 100, "playbackVolume": 0, "type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "inputChannels": 2, "outputChannels": 2, "loopback": false, "enabled": true, "authToken": "foobar", "broadcast": 1, "expiresAt": "2020-04-09T13:00:00Z"}`
 	target = AgentConfig{}
 	json.Unmarshal([]byte(raw), &target)
 	assert.Equal(3, target.Period)
@@ -102,6 +102,8 @@ func TestAgentConfig(t *testing.T) {
 	assert.Equal(false, bool(target.LoopBack))
 	assert.Equal(true, bool(target.Enabled))
 	assert.Equal("foobar", target.AuthToken)
+	assert.Equal(Public, target.Broadcast)
+	assert.Equal(int64(1586437200), target.ExpiresAt.Unix())
 }
 
 func TestAgentCredentials(t *testing.T) {

--- a/pkg/client/servers_test.go
+++ b/pkg/client/servers_test.go
@@ -34,7 +34,7 @@ func TestServerConfig(t *testing.T) {
 	var target ServerConfig
 
 	// Parse JSON into ServerConfig struct
-	raw = `{"type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "stereo": true, "loopback": false, "enabled": true}`
+	raw = `{"type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "stereo": true, "broadcast": 1, "loopback": false, "enabled": true}`
 	target = ServerConfig{}
 	json.Unmarshal([]byte(raw), &target)
 	assert.Equal(JackTripJamulus, target.Type)
@@ -43,6 +43,7 @@ func TestServerConfig(t *testing.T) {
 	assert.Equal("a.b.com", target.Host)
 	assert.Equal(8000, target.Port)
 	assert.Equal(96000, target.SampleRate)
+	assert.Equal(Public, target.Broadcast)
 	assert.Equal(true, bool(target.Stereo))
 	assert.Equal(false, bool(target.LoopBack))
 	assert.Equal(true, bool(target.Enabled))


### PR DESCRIPTION
This might be a little preemptive but I think in order for studios to take some action prior to expiration they would need to be aware of the expiry time?