### PR TITLE
Deconstructing AgentConfig for devices and servers

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -58,7 +58,7 @@ const (
 var soundDeviceName = ""
 var soundDeviceType = ""
 var lastDeviceStatus = "starting"
-var currentDeviceConfig client.AgentConfig
+var currentDeviceConfig client.DeviceAgentConfig
 
 // runOnDevice is used to run jacktrip-agent on a raspberry pi device
 func runOnDevice(apiOrigin string) {
@@ -114,7 +114,7 @@ func runOnDevice(apiOrigin string) {
 
 	// start sending heartbeats and updating agent configs
 	wsm := WebSocketManager{
-		ConfigChannel:    make(chan client.AgentConfig, 100),
+		ConfigChannel:    make(chan client.DeviceAgentConfig, 100),
 		HeartbeatChannel: make(chan interface{}, 100),
 		APIOrigin:        apiOrigin,
 		Credentials:      credentials,
@@ -147,10 +147,6 @@ func deviceConfigUpdateHandler(wg *sync.WaitGroup, beat *client.DeviceHeartbeat,
 			log.Info("Config channel is closed")
 			return
 		}
-
-		// just copy over parameters that we want to silently ignore
-		currentDeviceConfig.Broadcast = newDeviceConfig.Broadcast
-		currentDeviceConfig.ExpiresAt = newDeviceConfig.ExpiresAt
 
 		if newDeviceConfig != currentDeviceConfig {
 			// remove secrets before logging
@@ -226,7 +222,7 @@ func sendDeviceHeartbeats(wg *sync.WaitGroup, beat *client.DeviceHeartbeat, wsm 
 }
 
 // handleDeviceUpdate handles updates to device configuratiosn
-func handleDeviceUpdate(beat *client.DeviceHeartbeat, credentials client.AgentCredentials, config client.AgentConfig) {
+func handleDeviceUpdate(beat *client.DeviceHeartbeat, credentials client.AgentCredentials, config client.DeviceAgentConfig) {
 	// update current config sooner, so that other goroutines will have the most up-to-date version
 	lastDeviceConfig := currentDeviceConfig
 	currentDeviceConfig = config
@@ -307,7 +303,7 @@ func getSoundDeviceType() string {
 }
 
 // updateALSASettings is used to update the settings for an ALSA sound card
-func updateALSASettings(config client.AgentConfig) {
+func updateALSASettings(config client.DeviceAgentConfig) {
 	switch soundDeviceType {
 	case "snd_rpi_hifiberry_dacplusadc":
 		fallthrough
@@ -325,7 +321,7 @@ func updateALSASettings(config client.AgentConfig) {
 }
 
 // updateALSASettings is used to update the settings for a HiFiBerry sound card
-func updateALSASettingsHiFiBerry(config client.AgentConfig) {
+func updateALSASettingsHiFiBerry(config client.DeviceAgentConfig) {
 	var v int
 	amixerDevice := fmt.Sprintf("hw:%s", soundDeviceName)
 
@@ -384,7 +380,7 @@ func updateALSASettingsHiFiBerry(config client.AgentConfig) {
 }
 
 // updateALSASettingsAudioInjector is used to update the settings for a Audio Injector Stereo sound card
-func updateALSASettingsAudioInjector(config client.AgentConfig) {
+func updateALSASettingsAudioInjector(config client.DeviceAgentConfig) {
 	var v int
 	amixerDevice := fmt.Sprintf("hw:%s", soundDeviceName)
 
@@ -427,7 +423,7 @@ func updateALSASettingsAudioInjector(config client.AgentConfig) {
 }
 
 // updateALSASettingsUSBAudioDevice is used to update the settings for a USB sound card
-func updateALSASettingsUSBAudioDevice(config client.AgentConfig) {
+func updateALSASettingsUSBAudioDevice(config client.DeviceAgentConfig) {
 	var v int
 	amixerDevice := fmt.Sprintf("hw:%s", soundDeviceName)
 
@@ -451,7 +447,7 @@ func updateALSASettingsUSBAudioDevice(config client.AgentConfig) {
 }
 
 // updateALSASettingsUSBPnPSoundDevice is used to update the settings for a USB sound card
-func updateALSASettingsUSBPnPSoundDevice(config client.AgentConfig) {
+func updateALSASettingsUSBPnPSoundDevice(config client.DeviceAgentConfig) {
 	var v int
 	amixerDevice := fmt.Sprintf("hw:%s", soundDeviceName)
 

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -32,8 +32,8 @@ const (
 )
 
 // sendHTTPHeartbeat sends HTTP heartbeat to api and receives latest config
-func sendHTTPHeartbeat(beat interface{}, credentials client.AgentCredentials, apiOrigin string) (client.AgentConfig, error) {
-	var config client.AgentConfig
+func sendHTTPHeartbeat(beat interface{}, credentials client.AgentCredentials, apiOrigin string) (client.DeviceAgentConfig, error) {
+	var config client.DeviceAgentConfig
 
 	// update and encode heartbeat content
 	beatBytes, err := json.Marshal(beat)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -48,7 +48,7 @@ const (
 )
 
 // updateServiceConfigs is used to update config for managed systemd services
-func updateServiceConfigs(config client.AgentConfig, remoteName string, isServer bool) {
+func updateServiceConfigs(config client.DeviceAgentConfig, remoteName string, isServer bool) {
 
 	// assume auto queue unless > 0
 	jackTripExtraOpts := "-q auto"
@@ -128,7 +128,7 @@ func updateServiceConfigs(config client.AgentConfig, remoteName string, isServer
 }
 
 // updateJamulusIni writes a new /tmp/jamulus.ini file using template at /var/lib/jacktrip/jamulus.ini
-func updateJamulusIni(config client.AgentConfig, remoteName string) {
+func updateJamulusIni(config client.DeviceAgentConfig, remoteName string) {
 	srcFileName := "/var/lib/jacktrip/jamulus.ini"
 	srcFile, err := os.Open(srcFileName)
 	if err != nil {
@@ -180,7 +180,7 @@ func updateJamulusIni(config client.AgentConfig, remoteName string) {
 }
 
 // restartAllServices is used to restart all of the managed systemd services
-func restartAllServices(config client.AgentConfig, isServer bool) {
+func restartAllServices(config client.DeviceAgentConfig, isServer bool) {
 	// create dbus connection to manage systemd units
 	conn, err := dbus.New()
 	if err != nil {

--- a/cmd/websocketManager.go
+++ b/cmd/websocketManager.go
@@ -33,7 +33,7 @@ type WebSocketManager struct {
 	IsInitialized    bool
 	APIOrigin        string
 	Credentials      client.AgentCredentials
-	ConfigChannel    chan client.AgentConfig
+	ConfigChannel    chan client.DeviceAgentConfig
 	HeartbeatChannel chan interface{}
 	HeartbeatPath    string
 }
@@ -103,7 +103,7 @@ func (wsm *WebSocketManager) recvConfigHandler(wg *sync.WaitGroup) {
 			continue
 		}
 
-		var config client.AgentConfig
+		var config client.DeviceAgentConfig
 		if err := json.Unmarshal(message, &config); err != nil {
 			log.Error(err, "Failed to unmarshal heartbeat response")
 			continue

--- a/pkg/client/devices.go
+++ b/pkg/client/devices.go
@@ -68,6 +68,22 @@ type ALSAConfig struct {
 	PlaybackVolume int `json:"playbackVolume" db:"playback_volume"`
 }
 
+// DeviceAgentConfig defines active configuration for a device
+type DeviceAgentConfig struct {
+	DeviceConfig
+	ALSAConfig
+	ServerConfig
+
+	// frames per period
+	Period int `json:"period" db:"period"`
+
+	// size of jitter queue buffer
+	QueueBuffer int `json:"queueBuffer" db:"queue_buffer"`
+
+	// authorization token used by jacktrip-agent to access studio servers
+	AuthToken string `json:"authToken" db:"auth_token"`
+}
+
 // AgentConfig defines active configuration for an agent
 type AgentConfig struct {
 	DeviceConfig

--- a/pkg/client/devices_test.go
+++ b/pkg/client/devices_test.go
@@ -102,8 +102,40 @@ func TestAgentConfig(t *testing.T) {
 	assert.Equal(false, bool(target.LoopBack))
 	assert.Equal(true, bool(target.Enabled))
 	assert.Equal("foobar", target.AuthToken)
-	assert.Equal(Public, target.Broadcast)
 	assert.Equal(int64(1586437200), target.ExpiresAt.Unix())
+}
+
+func TestDeviceAgentConfig(t *testing.T) {
+	assert := assert.New(t)
+	var raw string
+	var target DeviceAgentConfig
+
+	// Parse JSON into AgentConfig struct
+	raw = `{"period": 3, "queueBuffer": 128, "devicePort": 8000, "reverb": 42, "limiter": true, "compressor": 0, "quality": 2, "captureBoost": true, "playbackBoost": 0, "captureVolume": 100, "playbackVolume": 0, "type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "inputChannels": 2, "outputChannels": 2, "loopback": false, "enabled": true, "authToken": "foobar", "broadcast": 1, "expiresAt": "2020-04-09T13:00:00Z"}`
+	target = DeviceAgentConfig{}
+	json.Unmarshal([]byte(raw), &target)
+	assert.Equal(3, target.Period)
+	assert.Equal(128, target.QueueBuffer)
+	assert.Equal(8000, target.DevicePort)
+	assert.Equal(42, target.Reverb)
+	assert.Equal(true, bool(target.Limiter))
+	assert.Equal(false, bool(target.Compressor))
+	assert.Equal(2, target.Quality)
+	assert.Equal(true, bool(target.CaptureBoost))
+	assert.Equal(false, bool(target.PlaybackBoost))
+	assert.Equal(100, target.CaptureVolume)
+	assert.Equal(0, target.PlaybackVolume)
+	assert.Equal(JackTripJamulus, target.Type)
+	assert.Equal("main", target.MixBranch)
+	assert.Equal("echo hi", target.MixCode)
+	assert.Equal("a.b.com", target.Host)
+	assert.Equal(8000, target.Port)
+	assert.Equal(96000, target.SampleRate)
+	assert.Equal(2, target.InputChannels)
+	assert.Equal(2, target.OutputChannels)
+	assert.Equal(false, bool(target.LoopBack))
+	assert.Equal(true, bool(target.Enabled))
+	assert.Equal("foobar", target.AuthToken)
 }
 
 func TestAgentCredentials(t *testing.T) {

--- a/pkg/client/servers.go
+++ b/pkg/client/servers.go
@@ -15,6 +15,8 @@
 package client
 
 import (
+	"time"
+
 	"github.com/jmoiron/sqlx/types"
 )
 
@@ -75,11 +77,30 @@ type ServerConfig struct {
 	// true if client's audio should loop back to them
 	LoopBack types.BitBool `json:"loopback" db:"loopback"`
 
+	// true if enabled
+	Enabled types.BitBool `json:"enabled" db:"enabled"`
+}
+
+// ServerAgentConfig defines active configuration for a server
+type ServerAgentConfig struct {
+	DeviceConfig
+	ALSAConfig
+	ServerConfig
+
+	// frames per period
+	Period int `json:"period" db:"period"`
+
+	// size of jitter queue buffer
+	QueueBuffer int `json:"queueBuffer" db:"queue_buffer"`
+
+	// authorization token used by jacktrip-agent to access studio servers
+	AuthToken string `json:"authToken" db:"auth_token"`
+
 	// broadcast visibility of the audio server
 	Broadcast BroadcastVisibility `json:"broadcast" db:"broadcast"`
 
-	// true if enabled
-	Enabled types.BitBool `json:"enabled" db:"enabled"`
+	// timestamp when the server will automatically be paused
+	ExpiresAt time.Time `json:"expiresAt" db:"expires_at"`
 }
 
 // ServerHeartbeat is used to send heartbeat messages from servers / studios

--- a/pkg/client/servers_test.go
+++ b/pkg/client/servers_test.go
@@ -34,8 +34,28 @@ func TestServerConfig(t *testing.T) {
 	var target ServerConfig
 
 	// Parse JSON into ServerConfig struct
-	raw = `{"type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "stereo": true, "broadcast": 1, "loopback": false, "enabled": true}`
+	raw = `{"type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "stereo": true, "loopback": false, "enabled": true}`
 	target = ServerConfig{}
+	json.Unmarshal([]byte(raw), &target)
+	assert.Equal(JackTripJamulus, target.Type)
+	assert.Equal("main", target.MixBranch)
+	assert.Equal("echo hi", target.MixCode)
+	assert.Equal("a.b.com", target.Host)
+	assert.Equal(8000, target.Port)
+	assert.Equal(96000, target.SampleRate)
+	assert.Equal(true, bool(target.Stereo))
+	assert.Equal(false, bool(target.LoopBack))
+	assert.Equal(true, bool(target.Enabled))
+}
+
+func TestServerAgentConfig(t *testing.T) {
+	assert := assert.New(t)
+	var raw string
+	var target ServerAgentConfig
+
+	// Parse JSON into ServerAgentConfig struct
+	raw = `{"type": "JackTrip+Jamulus", "mixBranch": "main", "mixCode": "echo hi", "serverHost": "a.b.com", "serverPort": 8000, "sampleRate": 96000, "stereo": true, "broadcast": 1, "loopback": false, "enabled": true}`
+	target = ServerAgentConfig{}
 	json.Unmarshal([]byte(raw), &target)
 	assert.Equal(JackTripJamulus, target.Type)
 	assert.Equal("main", target.MixBranch)


### PR DESCRIPTION
Taking an initial stab at modifying the AgentConfig struct so we don't have to use this one object when modifying both device state and server state

What I've done:
* Splitting AgentConfig into DeviceAgentConfig and ServerAgentConfig
* Moving Broadcast out of ServerConfig and into ServerAgentConfig
* Leaving AgentConfig in for now