### PR TITLE
Revert "Removing Jamulus only studio type"

### DIFF
--- a/cmd/services.go
+++ b/cmd/services.go
@@ -262,6 +262,8 @@ func restartAllServices(config client.DeviceAgentConfig) {
 	switch config.Type {
 	case client.JackTrip:
 		servicesToStart = []string{JackServiceName, JackTripServiceName}
+	case client.Jamulus:
+		servicesToStart = []string{JackServiceName, JamulusServiceName}
 	case client.JackTripJamulus:
 		switch config.Quality {
 		case 0:

--- a/pkg/client/servers.go
+++ b/pkg/client/servers.go
@@ -30,6 +30,9 @@ const (
 	// JackTrip server (https://github.com/jacktrip/jacktrip)
 	JackTrip ServerType = "JackTrip"
 
+	// Jamulus server (https://github.com/corrados/jamulus)
+	Jamulus ServerType = "Jamulus"
+
 	// JackTripJamulus means both JackTrip AND Jamulus server
 	JackTripJamulus ServerType = "JackTrip+Jamulus"
 

--- a/pkg/client/servers_test.go
+++ b/pkg/client/servers_test.go
@@ -24,6 +24,7 @@ import (
 func TestConstants(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal(ServerType("JackTrip"), JackTrip)
+	assert.Equal(ServerType("Jamulus"), Jamulus)
 	assert.Equal(ServerType("JackTrip+Jamulus"), JackTripJamulus)
 }
 


### PR DESCRIPTION
Reverts jacktrip/jacktrip-agent#87

So we actually have a lot of self-hosted Jamulus studios that I'm not sure we can migrate. I'm thinking we leave Jamulus type in, but disable it in most of our API layer?